### PR TITLE
Newly restructured Wrapper

### DIFF
--- a/lib/models/constants.dart
+++ b/lib/models/constants.dart
@@ -1,6 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 
+class Constants {
+  static ValueNotifier<String> _pageToShow = ValueNotifier<String>("Sign In");
+
+  ValueNotifier<String> getPageToShow() {
+    return _pageToShow;
+  }
+
+  void setPageToShow(String newPage) {
+    _pageToShow.value = newPage;
+  }
+}
+
 const textInputDecoration = InputDecoration(
   hintText: 'Email',
   fillColor: Colors.white,

--- a/lib/pages/forgot_password.dart
+++ b/lib/pages/forgot_password.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:recipic/services/auth.dart';
 import 'package:recipic/models/constants.dart';
-import 'package:recipic/pages/sign_in.dart';
 import 'dart:developer';
 
 class ForgotPassword extends StatefulWidget {
@@ -16,7 +15,6 @@ class _ForgotPasswordState extends State<ForgotPassword> {
 
   final AuthService _auth = AuthService();
   final _formKey = GlobalKey<FormState>();
-  bool showSignInPage = false;
 
   // text field state
   String email = '';

--- a/lib/pages/forgot_password.dart
+++ b/lib/pages/forgot_password.dart
@@ -70,10 +70,6 @@ class _ForgotPasswordState extends State<ForgotPassword> {
 
   @override
   Widget build(BuildContext context) {
-    if (showSignInPage) {
-      return SignIn();
-    }
-    else {
       return Scaffold(
         backgroundColor: Colors.grey[350],
         appBar: AppBar(
@@ -85,9 +81,7 @@ class _ForgotPasswordState extends State<ForgotPassword> {
               icon: Icon(Icons.person),
               label: Text('Sign In'),
               onPressed: () {
-                setState(() {
-                  showSignInPage = true;
-                });
+                Constants().setPageToShow("Sign In");
               },
             ),
           ],
@@ -139,5 +133,4 @@ class _ForgotPasswordState extends State<ForgotPassword> {
         ),
       );
     }
-  }
 }

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:recipic/models/constants.dart';
 import 'package:recipic/services/auth.dart';
 
 class Home extends StatelessWidget {
@@ -18,6 +19,7 @@ class Home extends StatelessWidget {
             label: Text('Sign Out'),
             onPressed: () async {
               await _auth.signOut();
+              Constants().setPageToShow("Sign In");
             },
           ),
         ]

--- a/lib/pages/register.dart
+++ b/lib/pages/register.dart
@@ -88,6 +88,9 @@ class _RegisterState extends State<Register> {
                           error = 'please supply a valid email';
                         });
                       }
+                      else {
+                        Constants().setPageToShow("Sign In");
+                      }
                     }
                   },
                 ),

--- a/lib/pages/register.dart
+++ b/lib/pages/register.dart
@@ -44,10 +44,7 @@ class _RegisterState extends State<Register> {
               icon: Icon(Icons.person),
               label: Text('Sign In'),
               onPressed: () {
-                setState(() {
-                  showLoadingPage = false;
-                  showSignInPage = true;
-                });
+                Constants().setPageToShow("Sign In");
               },
             ),
           ],
@@ -84,12 +81,11 @@ class _RegisterState extends State<Register> {
                   ),
                   onPressed: () async {
                     if (_formKey.currentState.validate()){
-                      setState(() => showLoadingPage = true);
+                      Constants().setPageToShow("Loading");
                       dynamic result = await _auth.registerWithEmailAndPassword(email, password);
                       if(result == null){
                         setState(() {
                           error = 'please supply a valid email';
-                          showLoadingPage = false;
                         });
                       }
                     }

--- a/lib/pages/register.dart
+++ b/lib/pages/register.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:recipic/pages/sign_in.dart';
 import 'package:recipic/services/auth.dart';
 import 'package:recipic/models/constants.dart';
 
@@ -16,8 +15,6 @@ class _RegisterState extends State<Register> {
 
   final AuthService _auth = AuthService();
   final _formKey = GlobalKey<FormState>();
-  bool showLoadingPage = false;
-  bool showSignInPage = false;
 
   // text field state
   String email = '';
@@ -26,13 +23,6 @@ class _RegisterState extends State<Register> {
 
   @override
   Widget build(BuildContext context) {
-    if (showLoadingPage && !showSignInPage) {
-      return Loading();
-    }
-    else if (!showLoadingPage && showSignInPage) {
-      return SignIn();
-    }
-    else {
       return Scaffold(
         backgroundColor: Colors.grey[350],
         appBar: AppBar(
@@ -105,5 +95,4 @@ class _RegisterState extends State<Register> {
         ),
       );
     }
-  }
 }

--- a/lib/pages/register.dart
+++ b/lib/pages/register.dart
@@ -71,7 +71,6 @@ class _RegisterState extends State<Register> {
                   ),
                   onPressed: () async {
                     if (_formKey.currentState.validate()){
-                      Constants().setPageToShow("Loading");
                       dynamic result = await _auth.registerWithEmailAndPassword(email, password);
                       if(result == null){
                         setState(() {

--- a/lib/pages/sign_in.dart
+++ b/lib/pages/sign_in.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:recipic/pages/forgot_password.dart';
-import 'package:recipic/pages/register.dart';
 import 'package:recipic/services/auth.dart';
 import 'package:recipic/models/constants.dart';
 
@@ -17,11 +15,6 @@ class _SignInState extends State<SignIn> {
 
   final AuthService _auth = AuthService();
   final _formKey = GlobalKey<FormState>();
-
-  // These three boolean variables determine which page is shown when this widget is rebuilt
-  bool showLoadingPage = false;
-  bool showForgotPasswordPage = false;
-  bool showRegisterPage = false;
 
   // text field state
   String email = '';
@@ -93,7 +86,6 @@ class _SignInState extends State<SignIn> {
                             setState(() {
                               error =
                               'could not sign in with those credentials';
-                              showLoadingPage = false;
                             });
                           } else {
                             Constants().setPageToShow("Home");

--- a/lib/pages/sign_in.dart
+++ b/lib/pages/sign_in.dart
@@ -89,11 +89,14 @@ class _SignInState extends State<SignIn> {
                           dynamic result = await _auth
                               .signInWithEmailAndPassword(email, password);
                           if (result == null) {
+                            Constants().setPageToShow("Sign In");
                             setState(() {
                               error =
                               'could not sign in with those credentials';
                               showLoadingPage = false;
                             });
+                          } else {
+                            Constants().setPageToShow("Home");
                           }
                         }
                       },

--- a/lib/pages/sign_in.dart
+++ b/lib/pages/sign_in.dart
@@ -78,11 +78,9 @@ class _SignInState extends State<SignIn> {
                       ),
                       onPressed: () async {
                         if (_formKey.currentState.validate()) {
-                          Constants().setPageToShow("Loading");
                           dynamic result = await _auth
                               .signInWithEmailAndPassword(email, password);
                           if (result == null) {
-                            Constants().setPageToShow("Sign In");
                             setState(() {
                               error =
                               'could not sign in with those credentials';

--- a/lib/pages/sign_in.dart
+++ b/lib/pages/sign_in.dart
@@ -30,16 +30,6 @@ class _SignInState extends State<SignIn> {
 
   @override
   Widget build(BuildContext context) {
-    if (showLoadingPage && !showForgotPasswordPage && !showRegisterPage) {
-      return Loading();
-    }
-    else if (!showLoadingPage && showForgotPasswordPage && !showRegisterPage) {
-      return ForgotPassword();
-    }
-    else if (!showLoadingPage && !showForgotPasswordPage && showRegisterPage) {
-      return Register();
-    }
-    else {
       return Scaffold(
         backgroundColor: Colors.grey[350],
         appBar: AppBar(
@@ -51,12 +41,7 @@ class _SignInState extends State<SignIn> {
               icon: Icon(Icons.person),
               label: Text('Register'),
               onPressed: () {
-                setState(() {
-                  // Rebuild the widget, now showing the register page
-                  showLoadingPage = false;
-                  showForgotPasswordPage = false;
-                  showRegisterPage = true;
-                });
+                Constants().setPageToShow("Register");
               },
             ),
           ],
@@ -100,7 +85,7 @@ class _SignInState extends State<SignIn> {
                       ),
                       onPressed: () async {
                         if (_formKey.currentState.validate()) {
-                          setState(() => showLoadingPage = true);
+                          Constants().setPageToShow("Loading");
                           dynamic result = await _auth
                               .signInWithEmailAndPassword(email, password);
                           if (result == null) {
@@ -121,12 +106,7 @@ class _SignInState extends State<SignIn> {
                         ),
                         color: Colors.grey[800],
                         onPressed: () {
-                          setState(() {
-                            // Rebuild the widget, now showing the forgot password page
-                            showLoadingPage = false;
-                            showForgotPasswordPage = true;
-                            showRegisterPage = false;
-                          });
+                          Constants().setPageToShow("Forgot Password");
                         }
                     )
                   ],
@@ -142,5 +122,4 @@ class _SignInState extends State<SignIn> {
         ),
       );
     }
-  }
 }

--- a/lib/pages/wrapper.dart
+++ b/lib/pages/wrapper.dart
@@ -1,20 +1,38 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:recipic/models/user.dart';
-import 'package:recipic/pages/authenticate.dart';
+import 'package:recipic/models/constants.dart';
+import 'package:recipic/pages/forgot_password.dart';
 import 'package:recipic/pages/home.dart';
+import 'package:recipic/pages/register.dart';
+import 'package:recipic/pages/sign_in.dart';
 
-class Wrapper extends StatelessWidget {
+class Wrapper extends StatefulWidget {
+  @override
+  _WrapperState createState() => _WrapperState();
+}
+
+class _WrapperState extends State<Wrapper> {
   @override
   Widget build(BuildContext context) {
-
-    final user = Provider.of<User>(context);
-
-    // return either Loading or Authenticate
-    if (user == null){
-      return Authenticate();
-    } else {
-      return Home();
-    }
+    return Scaffold(
+      body: ValueListenableBuilder<String>(
+        valueListenable: Constants().getPageToShow(),
+        builder: (BuildContext context, String value, Widget child) {
+          switch (value) {
+            case "Loading":
+              return Loading();
+            case "Sign In":
+              return SignIn();
+            case "Register":
+              return Register();
+            case "Forgot Password":
+              return ForgotPassword();
+            case "Home":
+              return Home();
+            default:
+              return null;
+          }
+        },
+      ),
+    );
   }
 }


### PR DESCRIPTION
This newly restructured wrapper has full control over the navigation between individual pages in this multi-page app. This new wrapper is an improvement over the old code for two reasons:
1. It eliminates the need to explicitly implement page navigation inside each .dart file. Specifically, it allows us to use `setState()` ONLY for updating the current page, rather than also having to use it for navigating to other app pages. Therefore, the new wrapper more cohesively integrates the app's individual pages.
2. It is more useful than the old wrapper, which only loaded the Authenticate and Home pages - a relatively trivial task.

The power of this new wrapper comes from a `ValueListenableBuilder`. This class gives an app the ability to redraw a widget if a variable (called the *value notifier*) is updated. Specifically in this case, the value notifier is a string that takes on values “Loading”, “Sign In”, “Register”, “Forgot Password”, and “Home”.

The app is redrawn whenever the value of this string changes. For example, if a user is on the Sign In page, and they click the Register button in the app bar, this button will update the value notifier from the string “Sign In” to the string “Register”. Because the value notifier got updated, the `ValueListenableBuilder` tells the wrapper that the app needs to be redrawn, and thus the app will now show the Register page. This is also true vice versa, as well as for the Forgot Password page.
